### PR TITLE
Test pass when built-in with another gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test/fixtures/GeoLite2-City.mmdb
+mruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ install:
   - sudo apt-get -qq install rake bison git gperf
   - sudo apt-get install -y libmaxminddb0 libmaxminddb-dev mmdb-bin
 before_script:
-  - gzip -cd test/fixtures/GeoLite2-City.mmdb.gz > test/fixtures/GeoLite2-City.mmdb
-  - cd ../
   - git clone https://github.com/mruby/mruby.git
+  - cp -fp .travis_build_config.rb mruby/build_config.rb
   - cd mruby
-  - cp -fp ../mruby-maxminddb/.travis_build_config.rb build_config.rb
 script:
   - make all test

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -1,7 +1,7 @@
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
-  conf.gem '../mruby-maxminddb'
+  conf.gem '../'
   conf.enable_test
   conf.linker.libraries << 'maxminddb'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,4 +2,17 @@ MRuby::Gem::Specification.new('mruby-maxminddb') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Kenichi Mitsugi'
   spec.add_test_dependency 'mruby-io', :mgem => 'mruby-io'
+
+  def maxminddb_origin_path
+    if File.exist?("../test/fixtures/GeoLite2-City.mmdb.gz")
+      "#{build.build_dir}/../../../test/fixtures/GeoLite2-City.mmdb"
+    else
+      "#{build.build_dir}/../mrbgems/mruby-maxminddb/test/fixtures/GeoLite2-City.mmdb"
+    end
+  end
+
+  maxminddb_ci_path = "#{build.build_dir}/../maxminddb-fixtures/GeoLite2-City.mmdb"
+
+  sh "mkdir -p #{File.dirname maxminddb_ci_path}"
+  sh "gzip -cd #{maxminddb_origin_path}.gz > #{maxminddb_ci_path}" unless File.exist?(maxminddb_ci_path)
 end

--- a/test/mrb_maxminddb.rb
+++ b/test/mrb_maxminddb.rb
@@ -2,7 +2,7 @@
 ## MaxMindDB Test
 ##
 
-MaxMindDbDat = File.expand_path("../mruby-maxminddb/test/fixtures/GeoLite2-City.mmdb")
+MaxMindDbDat = File.expand_path("./build/maxminddb-fixtures/GeoLite2-City.mmdb")
 
 FullDataExpect = {
   :ip_addr      => "9.9.9.9",


### PR DESCRIPTION
@happysiro 

Hi!

If mruby-maxminddb is used with another gem, the test fails because it is incorrect for the mmdb path referenced in the test.

Changed the path for single test or built-in test.

I confirmed that the test passed. This is the evidence.

- repo: https://github.com/takumakume/mruby-maxminddb-test
- CI result: https://travis-ci.org/takumakume/mruby-maxminddb-test/jobs/342742057#L872

Please check.