### PR TITLE
Fix leaks.

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -11,4 +11,6 @@ MRuby::Gem::Specification.new('mruby-maxminddb') do |spec|
 
   sh "mkdir -p #{File.dirname maxminddb_ci_path}"
   sh "gzip -cd #{maxminddb_origin_path}.gz > #{maxminddb_ci_path}" unless File.exist?(maxminddb_ci_path)
+
+  linker.libraries << 'maxminddb'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,11 +4,7 @@ MRuby::Gem::Specification.new('mruby-maxminddb') do |spec|
   spec.add_test_dependency 'mruby-io', :mgem => 'mruby-io'
 
   def maxminddb_origin_path
-    if File.exist?("../test/fixtures/GeoLite2-City.mmdb.gz")
-      "#{build.build_dir}/../../../test/fixtures/GeoLite2-City.mmdb"
-    else
-      "#{build.build_dir}/../mrbgems/mruby-maxminddb/test/fixtures/GeoLite2-City.mmdb"
-    end
+    "#{dir}/test/fixtures/GeoLite2-City.mmdb"
   end
 
   maxminddb_ci_path = "#{build.build_dir}/../maxminddb-fixtures/GeoLite2-City.mmdb"

--- a/src/mrb_maxminddb.c
+++ b/src/mrb_maxminddb.c
@@ -10,6 +10,7 @@
 #include "maxminddb-compat-util.h"
 
 #include "mruby.h"
+#include "mruby/class.h"
 #include "mruby/data.h"
 #include "mrb_maxminddb.h"
 
@@ -276,6 +277,7 @@ static mrb_value mrb_maxminddb_time_zone(mrb_state *mrb, mrb_value self) {
 void mrb_mruby_maxminddb_gem_init(mrb_state *mrb) {
   struct RClass *maxminddb;
   maxminddb = mrb_define_class(mrb, "MaxMindDB", mrb->object_class);
+  MRB_SET_INSTANCE_TT(maxminddb, MRB_TT_DATA);
   mrb_define_method(mrb, maxminddb, "initialize", mrb_maxminddb_init,
                     MRB_ARGS_REQ(1));
   mrb_define_method(mrb, maxminddb, "lookup_string",

--- a/src/mrb_maxminddb.c
+++ b/src/mrb_maxminddb.c
@@ -29,6 +29,7 @@ typedef struct {
 static void mrb_maxminddb_free(mrb_state *mrb, void *p) {
   mrb_maxminddb_data *data = p;
   MMDB_close(&(data->mmdb));
+  mrb_free(mrb, p);
 }
 
 static const struct mrb_data_type mrb_maxminddb_data_type = {
@@ -58,6 +59,7 @@ static mrb_value mrb_maxminddb_init(mrb_state *mrb, mrb_value self) {
   int status = MMDB_open(data->db, MMDB_MODE_MMAP, &(data->mmdb));
 
   if (MMDB_SUCCESS != status) {
+    mrb_free(mrb, data);
     mrb_raise(mrb, E_RUNTIME_ERROR, "Open Error");
   }
 

--- a/src/mrb_maxminddb.c
+++ b/src/mrb_maxminddb.c
@@ -107,8 +107,8 @@ static mrb_value mrb_maxminddb_country_code(mrb_state *mrb, mrb_value self) {
   if (MMDB_SUCCESS != status)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MMDB_aget_value error");
 
-  return mrb_str_new_cstr(
-      mrb, mmdb_strndup((char *)entry_data.utf8_string, entry_data.data_size));
+  return mrb_str_new(
+      mrb, (char *)entry_data.utf8_string, entry_data.data_size);
 }
 
 static mrb_value mrb_maxminddb_region(mrb_state *mrb, mrb_value self) {
@@ -128,8 +128,8 @@ static mrb_value mrb_maxminddb_region(mrb_state *mrb, mrb_value self) {
   if (MMDB_SUCCESS != status)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MMDB_aget_value error");
 
-  return mrb_str_new_cstr(
-      mrb, mmdb_strndup((char *)entry_data.utf8_string, entry_data.data_size));
+  return mrb_str_new(
+      mrb, (char *)entry_data.utf8_string, entry_data.data_size);
 }
 
 static mrb_value mrb_maxminddb_region_name(mrb_state *mrb, mrb_value self) {
@@ -149,8 +149,8 @@ static mrb_value mrb_maxminddb_region_name(mrb_state *mrb, mrb_value self) {
   if (MMDB_SUCCESS != status)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MMDB_aget_value error");
 
-  return mrb_str_new_cstr(
-      mrb, mmdb_strndup((char *)entry_data.utf8_string, entry_data.data_size));
+  return mrb_str_new(
+      mrb, (char *)entry_data.utf8_string, entry_data.data_size);
 }
 
 static mrb_value mrb_maxminddb_city(mrb_state *mrb, mrb_value self) {
@@ -170,8 +170,8 @@ static mrb_value mrb_maxminddb_city(mrb_state *mrb, mrb_value self) {
   if (MMDB_SUCCESS != status)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MMDB_aget_value error");
 
-  return mrb_str_new_cstr(
-      mrb, mmdb_strndup((char *)entry_data.utf8_string, entry_data.data_size));
+  return mrb_str_new(
+      mrb, (char *)entry_data.utf8_string, entry_data.data_size);
 }
 
 static mrb_value mrb_maxminddb_postal_code(mrb_state *mrb, mrb_value self) {
@@ -191,8 +191,8 @@ static mrb_value mrb_maxminddb_postal_code(mrb_state *mrb, mrb_value self) {
   if (MMDB_SUCCESS != status)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MMDB_aget_value error");
 
-  return mrb_str_new_cstr(
-      mrb, mmdb_strndup((char *)entry_data.utf8_string, entry_data.data_size));
+  return mrb_str_new(
+      mrb, (char *)entry_data.utf8_string, entry_data.data_size);
 }
 
 static mrb_value mrb_maxminddb_latitude(mrb_state *mrb, mrb_value self) {
@@ -272,8 +272,8 @@ static mrb_value mrb_maxminddb_time_zone(mrb_state *mrb, mrb_value self) {
   if (MMDB_SUCCESS != status)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MMDB_aget_value error");
 
-  return mrb_str_new_cstr(
-      mrb, mmdb_strndup((char *)entry_data.utf8_string, entry_data.data_size));
+  return mrb_str_new(
+      mrb, (char *)entry_data.utf8_string, entry_data.data_size);
 }
 
 void mrb_mruby_maxminddb_gem_init(mrb_state *mrb) {


### PR DESCRIPTION
- Use `dir` method instead to get fixture path.
- Specify library.
- Set type tag to fix leaks.
- Free memory allocated by mruby VM.
- Use `mrb_str_new` instead.
